### PR TITLE
No --threads:on required for single-threaded apps

### DIFF
--- a/tests/multithread.nim
+++ b/tests/multithread.nim
@@ -1,3 +1,4 @@
+# Compile with --threads:on
 # Purpose of this test is to ensure that syslog module is thread-safe
 # THREAD0 is expected to output same counter in APP-NAME and message content
 # THREAD1 and THREAD2 are expected to output somethimes different counters

--- a/tests/singlethread.nim
+++ b/tests/singlethread.nim
@@ -1,0 +1,15 @@
+# Works both with --threads:off and --threads:on
+
+import syslog
+
+openlog("singlethread", logUser)
+debug("Debug")
+info("Info")
+notice("Notice")
+warning("Warning")
+warn("Warn")
+error("Error")
+crit("Crit")
+alert("Alert")
+emerg("Emerg")
+closelog()


### PR DESCRIPTION
Locks are compiled now only for multithreaded applications.
