### PR TITLE
Use 'Sockaddr_un' instead of 'SockAddr'. Fixes #5

### DIFF
--- a/syslog.nimble
+++ b/syslog.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          = "syslog"
-version       = "0.0.2"
+version       = "0.0.3"
 author        = "Federico Ceratto"
 description   = """Minimal syslog support."""
 license       = "LGPLv3"


### PR DESCRIPTION
This should fix #5.

[`SockAddr`](https://github.com/nim-lang/Nim/blob/01ae0d28d47ef4cdd26e1f1f04e40aa9ae6ffe2b/lib/posix/posix.nim#L463) was used instead of [`Sockaddr_un`](https://github.com/nim-lang/Nim/blob/01ae0d28d47ef4cdd26e1f1f04e40aa9ae6ffe2b/lib/posix/posix.nim#L468) in despite of `AF_UNIX` address family is used.

So I rewrote code to use correct socket address structure.