### PR TITLE
Add support for log masks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,10 +18,25 @@ syslog.openlog("MyApp", logUser)  # optional
 syslog.info("Good news")
 syslog.debug("Psst")
 syslog(logAlert, "Alert!")
+
 syslog.closelog()  # optional
 ----
 
 Supported priorities: emerg, alert, crit, error, info, debug, notice, warn[ing]
+
+Only events with severity levels in the current mask are logged
+
+[source,nim]
+----
+let currentMask = getlogmask()
+
+let prevMask = setlogmask({ logAlert })
+syslog.debug("Psst")    # ignored
+syslog.alert("Alert!")  # logged
+discard setlogmask(prevMask)
+----
+
+Installation:
 
 [source,bash]
 ----

--- a/tests/singlethread.nim
+++ b/tests/singlethread.nim
@@ -2,14 +2,22 @@
 
 import syslog
 
+proc logAll() =
+  debug("Debug")
+  info("Info")
+  notice("Notice")
+  warning("Warning")
+  warn("Warn")
+  error("Error")
+  crit("Crit")
+  alert("Alert")
+  emerg("Emerg")
+
 openlog("singlethread", logUser)
-debug("Debug")
-info("Info")
-notice("Notice")
-warning("Warning")
-warn("Warn")
-error("Error")
-crit("Crit")
-alert("Alert")
-emerg("Emerg")
+logAll()
+let prev = setlogmask({ logDebug, logEmerg })
+logAll()
+discard setlogmask(prev)
+logAll()
 closelog()
+


### PR DESCRIPTION
Added functions `setlogmask()` and `getlogmask()` in order to implement functionality provided by syslog `setlogmask` (https://linux.die.net/man/3/setlogmask).
Differences between this implementation and original:

- I used `set[SyslogSeverity]` instead of bitmasks,
- I opted for a new function, `getlogmask()`, instead of passing 0 to `setlogmask()`, which allows blocking all logging attempts and makes the interface more intuitive.